### PR TITLE
Added forgotten smoothing length rescaling in KS project_pixel_grid.

### DIFF
--- a/morpholopy/plotter/KS_relation.py
+++ b/morpholopy/plotter/KS_relation.py
@@ -19,6 +19,11 @@ def project_pixel_grid(data, mode, res, region, rotation_matrix, backend):
     x_range = x_max - x_min
     y_range = y_max - y_min
 
+    if not np.isclose(x_range, y_range):
+        raise AttributeError(
+            "Projection code is currently not able to handle non-square images"
+        )
+
     if mode == 0:
         m = data[:, 9]  # H2
     if mode == 1:
@@ -41,8 +46,8 @@ def project_pixel_grid(data, mode, res, region, rotation_matrix, backend):
     if backend=="histogram":
         h = np.empty_like(m)
     else:
-        h = data[:,7]
-    
+        h = data[:,7] / x_range
+
     image = backends[backend](x=x, y=y, m=m, h=h, res=res)
     return image
 


### PR DESCRIPTION
To use `swiftsimio`'s subsampled backend, the smoothing lengths need to be rescaled to the same units as the x and y coordinates. #11 did not do this. As a result, the maps will be too smooth and likely overestimate the surface density.

The projection only works if the x and y units are the same, so I added an additional check to make sure this is always the case.