### PR TITLE
Replaced CMRmap with gnuplot to avoid white dots on a white background

### DIFF
--- a/morpholopy/plotter/plot_morphology.py
+++ b/morpholopy/plotter/plot_morphology.py
@@ -227,7 +227,7 @@ def plot_surface_densities(
         s=25,
         vmin=6,
         vmax=10,
-        cmap="CMRmap_r",
+        cmap="gnuplot_r",
         edgecolors="none",
         zorder=2,
     )
@@ -276,7 +276,7 @@ def plot_surface_densities(
         s=25,
         vmin=6,
         vmax=10,
-        cmap="CMRmap_r",
+        cmap="gnuplot_r",
         edgecolors="none",
         zorder=2,
     )

--- a/morpholopy/plotter/plot_surface_densities.py
+++ b/morpholopy/plotter/plot_surface_densities.py
@@ -6,7 +6,7 @@ import numpy as np
 from matplotlib import cm as cmm
 from matplotlib.colors import ListedColormap
 
-top = cmm.get_cmap("CMRmap_r", 256)
+top = cmm.get_cmap("gnuplot_r", 256)
 newcolors = top(np.linspace(0.1, 0.9, 230))
 newcmp = ListedColormap(newcolors, name="custombar")
 
@@ -642,7 +642,7 @@ def plot_combined_surface_densities(
         s=5,
         vmin=-3,
         vmax=1,
-        cmap="CMRmap_r",
+        cmap="gnuplot_r",
         edgecolors="none",
         zorder=2,
         label="method:grid",


### PR DESCRIPTION
Some scatter plots use the colour map `CMRmap`, which uses white for its highest value (or lowest value if you use `CMRmap_r`). That means those points will not be visible on a white background, as illustrated here: https://swift.dur.ac.uk/COLIBREPlots/richings/morphology_L012N0188_chimes_run11_z0/combined_surface_density_ratios_run11.png.

I have replaced `CMRmap` with `gnuplot`, which is very similar but is yellow at the high end.